### PR TITLE
docs: add contributing guidelines and templates for Terraform modules

### DIFF
--- a/contribute/CONTRIBUTING.md
+++ b/contribute/CONTRIBUTING.md
@@ -1,0 +1,226 @@
+# Contributing to Terraform Starter Kits
+
+Thank you for your interest in contributing to the CoderCo Terraform Starter Kits! This repository is a community project, and we welcome contributions from all skill levels.
+
+## Table of Contents
+- [Getting Started](#getting-started)
+- [Ways to Contribute](#ways-to-contribute)
+- [Development Setup](#development-setup)
+- [Creating a Module](#creating-a-module)
+- [Adding an Example](#adding-an-example)
+- [Testing](#testing)
+- [Code Standards](#code-standards)
+- [Submitting Changes](#submitting-changes)
+- [Code of Conduct](#code-of-conduct)
+
+## Getting Started
+
+1. Fork the repository on GitHub
+2. Clone your fork and create a feature branch:
+   ```bash
+   Example:
+   git clone https://github.com/YOUR-USERNAME/terraform-starter-kit.git
+   git checkout -b feature/your-feature-name
+   ```
+3. Make your changes and commit them
+4. Push to your fork and submit a Pull Request to the `dev` branch
+
+## Ways to Contribute
+
+### Documentation
+- Improve README files in modules or examples
+- Add comments to complex Terraform code
+- Create tutorials or guides
+- Fix typos and clarify confusing sections
+
+### New Modules
+- Create reusable modules for common AWS patterns
+- Follow the existing [Module Structure](#module-structure)
+- Include complete variable documentation
+- Add working examples
+
+### New Examples
+- Add examples that demonstrate module usage
+- Create examples for different use cases (production, dev, testing)
+- Document each example thoroughly
+- Test examples before submitting
+
+### Testing
+- Add Terratest tests for modules
+- Improve test coverage
+- Test examples in real AWS environments
+- Document testing procedures
+
+### Bug Fixes
+- Report issues with clear reproduction steps
+- Submit PRs with fixes
+- Include tests that verify the fix
+
+### Improvements
+- Optimise existing modules
+- Add features or configurations
+- Improve code readability
+- Enhance security best practices
+
+## Development Setup
+
+### Prerequisites
+- **Terraform** >= 1.0
+- **Go** >= 1.19 (for testing with Terratest)
+- **AWS CLI** configured with credentials
+- **Git**
+
+### Local Setup
+```bash
+# Clone your fork
+git clone https://github.com/YOUR-USERNAME/terraform-starter-kit.git
+cd terraform-starter-kit
+
+# Install pre-commit hooks (optional)
+pre-commit install
+
+# Verify Terraform formatting
+terraform fmt -recursive .
+```
+
+## Creating a Module
+
+### Directory Structure
+Create your module following this pattern:
+```
+modules/aws/your-module/
+├── README.md              # Module documentation
+├── main.tf                # Resource definitions
+├── variables.tf           # Input variables
+├── outputs.tf             # Output values
+├── provider.tf            # Provider configuration
+└── versions.tf            # Provider version constraints
+
+examples/aws/your-module/
+├── main.tf
+├── outputs.tf
+└── README.md
+```
+
+### Managing Module Versions
+Keep previous versions of modules for backward compatibility:
+```
+modules/aws/
+├── your-module/           # Current version
+│   ├── README.md
+│   ├── main.tf
+│   └── ...
+└── previous-versions/
+    └── your-module-v1.0/  # Previous stable version
+        ├── README.md
+        ├── main.tf
+        └── ...
+
+examples/aws/
+├── your-module/           # Current version example
+│   ├── main.tf
+│   └── outputs.tf
+└── previous-versions/
+    └── your-module-v1.0/  # Example for previous version
+        ├── main.tf
+        ├── outputs.tf
+        └── README.md
+```
+
+### README.md
+
+For detailed template, see [terraform-module-readme-template.md](./terraform-module-readme-template.md)
+
+
+### Adding an Example
+
+- Fully functional and tested
+- Include README at the example level documenting the use case (see [terraform-module-readme-template.md](./terraform-module-readme-template.md))
+- Provides realistic use case
+- Includes cleanup instructions
+
+## Testing
+
+### Running Tests
+
+```bash
+# Run all tests
+cd terratest
+go test -v ./...
+
+# Run specific test
+go test -v ./aws/vpc_test.go
+
+# With timeout
+go test -v -timeout 30m ./...
+```
+
+### Writing Tests
+
+Create tests in `terratest/` following the Terratest framework.
+
+Example:
+```go
+package test
+
+func TestVPC(t *testing.T) {
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../../examples/aws-vpc-basic",
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+}
+```
+
+### Test Requirements
+- Tests must be idempotent
+- Clean up resources (use `defer terraform.Destroy()`)
+- Document what's being tested
+- Use meaningful assertions
+
+## Code Standards
+
+For Terraform code standards, naming conventions, best practices, and formatting guidelines, please refer to [terraform-standards.md](./terraform-standards.md).
+
+## Submitting Changes
+
+For a complete pre-submission checklist and PR guidelines, please refer to [pull-request-guidelines.md](./pull-request-guidelines.md).
+
+## Common Issues
+
+### Terraform State Management
+- Don't commit `.tfstate` files
+- Use remote state in real projects
+- Examples should use local state
+
+### Sensitive Data
+- Never commit AWS keys or secrets
+- Use variables for sensitive values
+- Use `.gitignore` to exclude `.tfvars`
+
+### AWS Provider Configuration
+- Don't hardcode regions or credentials
+- Use variables for provider configuration
+- Assume users will configure AWS CLI
+
+## Getting Help
+
+- **Issues**: Search existing or create a new one
+- **Discussions**: Use GitHub discussions for questions
+- **Pull Request Reviews**: Ask maintainers if stuck
+
+## Code of Conduct
+
+- Be respectful and inclusive
+- Welcome different experience levels
+- Provide constructive feedback
+- Celebrate contributions from all
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the same license as the project.
+
+---
+
+Thank you for contributing to make Terraform more accessible!

--- a/contribute/CONTRIBUTING.md
+++ b/contribute/CONTRIBUTING.md
@@ -111,20 +111,22 @@ modules/aws/
 │   ├── main.tf
 │   └── ...
 └── previous-versions/
-    └── your-module-v1.0/  # Previous stable version
-        ├── README.md
-        ├── main.tf
-        └── ...
+    └── your-module/
+        └── v1.0/
+            ├── README.md
+            ├── main.tf
+            └── ...
 
 examples/aws/
 ├── your-module/           # Current version example
 │   ├── main.tf
 │   └── outputs.tf
 └── previous-versions/
-    └── your-module-v1.0/  # Example for previous version
-        ├── main.tf
-        ├── outputs.tf
-        └── README.md
+    └── your-module/
+        └── v1.0/
+            ├── main.tf
+            ├── outputs.tf
+            └── README.md
 ```
 
 ### README.md

--- a/contribute/README.md
+++ b/contribute/README.md
@@ -27,40 +27,12 @@ Thank you for your interest in contributing to the CoderCo Terraform Starter Kit
 
 ## Ways to Contribute
 
-### Documentation
-- Improve README files in modules or examples
-- Add comments to complex Terraform code
-- Create tutorials or guides
-- Fix typos and clarify confusing sections
-
-### New Modules
-- Create reusable modules for common AWS patterns
-- Follow the existing [Module Structure](#module-structure)
-- Include complete variable documentation
-- Add working examples
-
-### New Examples
-- Add examples that demonstrate module usage
-- Create examples for different use cases (production, dev, testing)
-- Document each example thoroughly
-- Test examples before submitting
-
-### Testing
-- Add Terratest tests for modules
-- Improve test coverage
-- Test examples in real AWS environments
-- Document testing procedures
-
-### Bug Fixes
-- Report issues with clear reproduction steps
-- Submit PRs with fixes
-- Include tests that verify the fix
-
-### Improvements
-- Optimise existing modules
-- Add features or configurations
-- Improve code readability
-- Enhance security best practices
+- **Documentation** - Improve guides and docs
+- **New Modules** - Create reusable infrastructure components
+- **New Examples** - Share practical use cases
+- **Testing** - Add Terratest coverage
+- **Bug Fixes** - Report and fix issues
+- **Improvements** - Enhance existing features
 
 ## Development Setup
 
@@ -189,23 +161,6 @@ For Terraform code standards, naming conventions, best practices, and formatting
 
 For a complete pre-submission checklist and PR guidelines, please refer to [pull-request-guidelines.md](./pull-request-guidelines.md).
 
-## Common Issues
-
-### Terraform State Management
-- Don't commit `.tfstate` files
-- Use remote state in real projects
-- Examples should use local state
-
-### Sensitive Data
-- Never commit AWS keys or secrets
-- Use variables for sensitive values
-- Use `.gitignore` to exclude `.tfvars`
-
-### AWS Provider Configuration
-- Don't hardcode regions or credentials
-- Use variables for provider configuration
-- Assume users will configure AWS CLI
-
 ## Getting Help
 
 - **Issues**: Search existing or create a new one
@@ -222,7 +177,3 @@ For a complete pre-submission checklist and PR guidelines, please refer to [pull
 ## License
 
 By contributing, you agree that your contributions will be licensed under the same license as the project.
-
----
-
-Thank you for contributing to make Terraform more accessible!

--- a/contribute/pull-request-guidelines.md
+++ b/contribute/pull-request-guidelines.md
@@ -20,40 +20,42 @@
 Use this format for all PRs:
 
 ```markdown
-# Title: feat: Add S3 bucket module
-(The title should match or reference the issue name)
+## Summary
+<!-- Briefly describe what this PR changes and why -->
 
-## Description
-Brief description of what this PR does.
+## Context / Motivation
+<!-- Why is this change needed? What problem does it solve? -->
 
-## Changes
-- List of specific changes made
-- Another change
-- One more change
-
-## Why
-Explain the reasoning behind these changes.
-
-## Testing
-How did you test this?
-- [ ] Tested locally
-- [ ] Added unit tests
-- [ ] Tested in real environment
-- [ ] Tested edge cases
-
-## Screenshots (if applicable)
-Add screenshots or terminal output.
+## Type of Change
+<!-- Check all that apply -->
+- [ ] Terraform module
+- [ ] Example update
+- [ ] Bug fix
+- [ ] Refactor
+- [ ] Documentation
+- [ ] CI / Tooling
 
 ## Related Issues
-Closes #123
-Related to #456
+<!-- Use "Closes #<issue>" to auto-close -->
+Closes #
+
+## Testing
+<!-- Check what was performed -->
+- [ ] terraform fmt
+- [ ] terraform validate
+- [ ] examples validated
+- [ ] tflint
+- [ ] terratest (if applicable)
+- [ ] not applicable (explain below)
+
+## Evidence / Notes
+<!-- Commands run, output, or anything reviewers should know -->
 
 ## Checklist
-- [ ] Code follows style guidelines
-- [ ] Self-review completed
-- [ ] Documentation updated
-- [ ] Tests added/updated
-- [ ] No breaking changes (or documented if present)
+- [ ] PR title is clear and descriptive
+- [ ] Code follows module conventions
+- [ ] Inputs and outputs are documented
+- [ ] No secrets or sensitive data included
 ```
 
 ## Review Process
@@ -68,35 +70,6 @@ Pull requests go to the `dev` branch first, then to `main` for production. A mai
 - Respond to feedback promptly
 - Test thoroughly before submitting
 - Update documentation in the same PR
-
-## What Makes a Good PR
-
-### Clear Title & Description
-- Explains **what** changed
-- Explains **why** it changed
-- Includes context for reviewers
-
-### Single Responsibility
-- One feature/fix per PR
-- Related changes grouped together
-- No unrelated modifications
-
-### Well-Structured Code
-- Clean, readable code
-- Follows project conventions
-- Includes comments where needed
-- No commented-out code
-- No debugging statements
-
-### Comprehensive Testing
-- Tests included
-- Edge cases covered
-- Manual testing documented
-
-### Updated Documentation
-- README updated if needed
-- Code comments added
-- Examples provided
 
 ## Responding to Review Feedback
 

--- a/contribute/pull-request-guidelines.md
+++ b/contribute/pull-request-guidelines.md
@@ -11,7 +11,7 @@
 - [ ] Examples work and are tested
 - [ ] No sensitive data in code or examples (no AWS keys, secrets, or credentials)
 - [ ] Commit messages are clear and descriptive
-- [ ] Branch is up to date with main
+- [ ] Branch is up to date with dev/main (depending on where you are pushing to)
 - [ ] No merge conflicts
 - [ ] Self-review completed
 

--- a/contribute/pull-request-guidelines.md
+++ b/contribute/pull-request-guidelines.md
@@ -1,0 +1,158 @@
+# Pull Request Guidelines
+
+## Before Opening a PR
+
+### ✅ Checklist
+
+- [ ] Code is formatted and follows standards (see [terraform-standards.md](./terraform-standards.md))
+- [ ] Code works and has been tested locally
+- [ ] All tests pass locally
+- [ ] README files are complete
+- [ ] Examples work and are tested
+- [ ] No sensitive data in code or examples (no AWS keys, secrets, or credentials)
+- [ ] Commit messages are clear and descriptive
+- [ ] Branch is up to date with main
+- [ ] No merge conflicts
+- [ ] Self-review completed
+
+## PR Format
+
+Use this format for all PRs:
+
+```markdown
+# Title: feat: Add S3 bucket module
+(The title should match or reference the issue name)
+
+## Description
+Brief description of what this PR does.
+
+## Changes
+- List of specific changes made
+- Another change
+- One more change
+
+## Why
+Explain the reasoning behind these changes.
+
+## Testing
+How did you test this?
+- [ ] Tested locally
+- [ ] Added unit tests
+- [ ] Tested in real environment
+- [ ] Tested edge cases
+
+## Screenshots (if applicable)
+Add screenshots or terminal output.
+
+## Related Issues
+Closes #123
+Related to #456
+
+## Checklist
+- [ ] Code follows style guidelines
+- [ ] Self-review completed
+- [ ] Documentation updated
+- [ ] Tests added/updated
+- [ ] No breaking changes (or documented if present)
+```
+
+## Review Process
+
+Pull requests go to the `dev` branch first, then to `main` for production. A maintainer will review your PR and merge once approved.
+
+## Good PR Practices
+
+- Keep PRs small (50-200 lines of changes)
+- One feature/fix per PR
+- Write clear, descriptive commit messages
+- Respond to feedback promptly
+- Test thoroughly before submitting
+- Update documentation in the same PR
+
+## What Makes a Good PR
+
+### Clear Title & Description
+- Explains **what** changed
+- Explains **why** it changed
+- Includes context for reviewers
+
+### Single Responsibility
+- One feature/fix per PR
+- Related changes grouped together
+- No unrelated modifications
+
+### Well-Structured Code
+- Clean, readable code
+- Follows project conventions
+- Includes comments where needed
+- No commented-out code
+- No debugging statements
+
+### Comprehensive Testing
+- Tests included
+- Edge cases covered
+- Manual testing documented
+
+### Updated Documentation
+- README updated if needed
+- Code comments added
+- Examples provided
+
+## Responding to Review Feedback
+
+### Be Receptive
+- Reviews make code better
+- Don't take feedback personally
+- Ask questions if unclear
+- Thank reviewers for their time
+
+### Try to respond to Every Comment
+- ✅ "Fixed in commit abc123"
+- ✅ "Good catch, updated"
+- ✅ "I disagree because X, what do you think?"
+- ✅ "Will address in follow-up PR"
+
+### Don't
+
+- ❌ Ignore comments
+- ❌ Get defensive or take it personally
+- ❌ Make changes without replying
+- ❌ Mark as resolved without addressing
+
+## Merging Your PR
+
+### Merge Requirements
+
+- ✅ Minimum approvals met
+- ✅ All CI checks pass
+- ✅ No unresolved comments
+- ✅ Up to date with main branch
+- ✅ Merge conflicts resolved
+
+### Merge Methods
+
+#### Squash and Merge (Recommended)
+
+- Combines all commits into one
+- Clean history on main
+- Use for feature branches
+
+#### Merge Commit
+
+- Preserves all commits
+- Shows complete history
+- Use for important features
+
+#### Rebase and Merge
+
+- Replays commits on main
+- Linear history
+- Use if commits are clean
+
+**Default**: Squash and Merge for most PRs
+
+## After Merging
+
+1. Delete the feature branch
+2. Close related issues
+3. Update project board

--- a/contribute/terraform-module-readme-template.md
+++ b/contribute/terraform-module-readme-template.md
@@ -1,0 +1,98 @@
+# Terraform Module README Templates
+
+<br>
+
+## Module README Template
+
+```markdown
+# Module Name - V1.0.0
+
+Brief description of what this module does.
+
+## Features
+
+- List key features of the module
+- Another important feature
+- Another capability
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.5 |
+| aws | >= 5.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| name | Resource name | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| id | Resource ID |
+
+## Examples
+
+See [examples/](./examples/) directory.
+
+## Notes
+
+- Resources are tagged with `ManagedBy = "Terraform"` automatically via provider default tags
+- All resource names are prefixed with the `name` variable for easy identification
+
+## Resources Created
+
+This module creates the following resources:
+
+- `aws_vpc`
+- `aws_subnet`
+- `aws_internet_gateway`
+
+## Previous Versions
+
+For previous versions of this module, see [previous-versions/](../previous-versions/) directory.
+```
+
+---
+
+<br>
+
+## Module Example README Template
+
+```markdown
+# Example Name - V1.0.0
+
+Brief description of what this example demonstrates.
+
+## Usage
+
+terraform init
+terraform plan
+terraform apply
+
+## What This Creates
+
+- List of AWS resources that will be created
+- Another resource  
+- Another resource
+
+## Requirements
+
+- AWS Provider >= 6.24.0
+- Terraform >= 1.5
+- Valid AWS credentials configured
+- Any other prerequisites (VPC, subnets, security groups, etc.)
+
+## Inputs
+
+See the main module README for all available variables.
+
+## Outputs
+
+After applying, you can access:
+
+- `output_name` - Description of output
+```

--- a/contribute/terraform-module-readme-template.md
+++ b/contribute/terraform-module-readme-template.md
@@ -1,4 +1,4 @@
-# Terraform Module README Templates
+# 'Terraform Module' README Templates
 
 <br>
 
@@ -60,7 +60,7 @@ For previous versions of this module, see [previous-versions/](../previous-versi
 
 <br>
 
-## Module Example README Template
+## 'Module Example' README Template
 
 ```markdown
 # Example Name - V1.0.0

--- a/contribute/terraform-standards.md
+++ b/contribute/terraform-standards.md
@@ -281,19 +281,20 @@ resource "aws_iam_role" "role" { }
 ```
 
 ### Always Add Tags
+
+Use provider `default_tags` for consistency across all resources:
+
 ```hcl
-resource "aws_vpc" "main" {
-  cidr_block = var.vpc_cidr_block
-  
-  tags = merge(
-    var.tags,
-    {
-      Name        = "${var.project_name}-vpc"
-      Environment = var.environment
+# In provider.tf
+provider "aws" {
+  default_tags {
+    tags = {
       ManagedBy   = "Terraform"
+      Module    = "CoderCo community module - xxx"
     }
-  )
+  }
 }
+
 ```
 
 ### Use Dynamic Blocks Wisely

--- a/contribute/terraform-standards.md
+++ b/contribute/terraform-standards.md
@@ -1,0 +1,598 @@
+# Terraform Standards
+
+## Project Structure
+
+### Standard Module Layout
+
+```
+modules/
+└── module-name/
+    ├── README.md
+    ├── main.tf
+    ├── variables.tf
+    ├── outputs.tf
+    ├── versions.tf
+    └── provider.tf
+
+examples/
+└── module-name/
+    ├── main.tf
+    └── outputs.tf
+```
+
+#### Example: VPC Module
+
+```
+modules/
+└── vpc/
+    ├── README.md
+    ├── main.tf
+    ├── variables.tf
+    ├── outputs.tf
+    ├── versions.tf
+    └── provider.tf
+
+examples/
+└── vpc/
+    ├── main.tf
+    └── outputs.tf
+```
+
+## File Organisation
+
+### versions.tf
+
+```hcl
+terraform {
+  required_version = ">= 1.5.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+```
+
+### provider.tf
+
+Provider configuration. Include default tags:
+
+```hcl
+provider "aws" {
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+    }
+  }
+}
+```
+
+### variables.tf
+
+All input variables with descriptions, types, and defaults.
+
+### outputs.tf
+
+All outputs with descriptions.
+
+### main.tf
+Main resource definitions
+
+### data.tf (optional)
+Data sources only
+
+### locals.tf (optional)
+Local values only
+
+## Naming Conventions
+
+### Resources
+```hcl
+# Format: <resource_type>_<descriptive_name>
+resource "aws_vpc" "main" { }
+resource "aws_subnet" "private" { }
+resource "aws_security_group" "web_server" { }
+```
+
+### Variables
+```hcl
+# Use snake_case
+variable "vpc_cidr_block" { }
+variable "enable_dns_hostnames" { }
+variable "instance_type" { }
+```
+
+### Outputs
+```hcl
+# Use snake_case, descriptive names
+output "vpc_id" { }
+output "private_subnet_ids" { }
+output "security_group_id" { }
+```
+
+### Modules
+```hcl
+# Use descriptive names
+module "vpc" { }
+module "application_load_balancer" { }
+module "rds_cluster" { }
+```
+
+## Variable Standards
+
+### Always Include
+1. Description
+2. Type
+3. Default (when appropriate)
+4. Validation (when needed)
+
+### Good Variable Example
+```hcl
+variable "instance_type" {
+  description = "EC2 instance type for application servers"
+  type        = string
+  default     = "t3.micro"
+  
+  validation {
+    condition     = can(regex("^t3\\.", var.instance_type))
+    error_message = "Instance type must be from t3 family."
+  }
+}
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+  
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be dev, staging, or prod."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+```
+
+### Variable Types
+
+#### Simple Types
+```hcl
+variable "string_var" {
+  type    = string
+  default = "value"
+}
+
+variable "number_var" {
+  type    = number
+  default = 42
+}
+
+variable "bool_var" {
+  type    = bool
+  default = true
+}
+```
+
+#### Complex Types
+```hcl
+variable "list_var" {
+  type    = list(string)
+  default = ["item1", "item2"]
+}
+
+variable "map_var" {
+  type = map(string)
+  default = {
+    key1 = "value1"
+    key2 = "value2"
+  }
+}
+
+variable "object_var" {
+  type = object({
+    name   = string
+    port   = number
+    health_check = object({
+      path     = string
+      interval = number
+    })
+  })
+}
+```
+
+### Input Validation
+
+Always validate inputs that have constraints:
+
+```hcl
+variable "cidr_block" {
+  description = "CIDR block for VPC"
+  type        = string
+  
+  validation {
+    condition     = can(cidrhost(var.cidr_block, 0))
+    error_message = "Must be valid IPv4 CIDR block."
+  }
+}
+
+variable "port" {
+  description = "Port number for application"
+  type        = number
+  
+  validation {
+    condition     = var.port > 0 && var.port < 65536
+    error_message = "Port must be between 1 and 65535."
+  }
+}
+```
+
+## Output Standards
+
+### Always Include Description
+```hcl
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "private_subnet_ids" {
+  description = "List of IDs of private subnets"
+  value       = aws_subnet.private[*].id
+}
+```
+
+### Mark Sensitive Outputs
+```hcl
+output "database_password" {
+  description = "Master password for database"
+  value       = random_password.db.result
+  sensitive   = true
+}
+```
+
+### Output Useful Information
+```hcl
+output "connection_info" {
+  description = "Connection information for the application"
+  value = {
+    endpoint = aws_lb.main.dns_name
+    port     = 443
+    url      = "https://${aws_lb.main.dns_name}"
+  }
+}
+```
+
+## Resource Standards
+
+### Use Descriptive Names
+```hcl
+# ✅ Good
+resource "aws_security_group" "web_server" { }
+resource "aws_iam_role" "ecs_task_execution" { }
+
+# ❌ Bad
+resource "aws_security_group" "sg1" { }
+resource "aws_iam_role" "role" { }
+```
+
+### Always Add Tags
+```hcl
+resource "aws_vpc" "main" {
+  cidr_block = var.vpc_cidr_block
+  
+  tags = merge(
+    var.tags,
+    {
+      Name        = "${var.project_name}-vpc"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  )
+}
+```
+
+### Use Dynamic Blocks Wisely
+```hcl
+# Good use case - variable number of items
+resource "aws_security_group" "main" {
+  name   = "example"
+  vpc_id = aws_vpc.main.id
+  
+  dynamic "ingress" {
+    for_each = var.ingress_rules
+    content {
+      from_port   = ingress.value.port
+      to_port     = ingress.value.port
+      protocol    = "tcp"
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+}
+```
+
+### Avoid Hardcoded Values
+```hcl
+# ❌ Bad
+resource "aws_instance" "web" {
+  ami           = "ami-0c55b159cbfafe1f0"
+  instance_type = "t3.micro"
+  subnet_id     = "subnet-12345"
+}
+
+# ✅ Good
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+  subnet_id     = var.subnet_id
+}
+```
+
+## State Management
+
+### Remote State
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "my-terraform-state"
+    key            = "prod/vpc/terraform.tfstate"
+    region         = "eu-west-2"
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
+  }
+}
+```
+
+### State Best Practices
+- Always use remote state for team projects
+- Enable state locking
+- Encrypt state at rest
+- Use separate states for different environments
+- Never commit state files to git
+
+## Security Best Practices
+
+### Never Hardcode Secrets
+```hcl
+# ❌ Bad - secret in code
+resource "aws_db_instance" "main" {
+  password = "SuperSecret123!"
+}
+
+# ✅ Good - use secrets manager or variables
+resource "aws_db_instance" "main" {
+  password = random_password.db.result
+}
+
+resource "random_password" "db" {
+  length  = 32
+  special = true
+}
+```
+
+### Use Data Sources for Sensitive Info
+```hcl
+data "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = "prod/db/password"
+}
+
+resource "aws_db_instance" "main" {
+  password = data.aws_secretsmanager_secret_version.db_password.secret_string
+}
+```
+
+### Restrict Resource Access
+```hcl
+resource "aws_s3_bucket" "main" {
+  bucket = "my-bucket"
+}
+
+resource "aws_s3_bucket_public_access_block" "main" {
+  bucket = aws_s3_bucket.main.id
+  
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+```
+
+## Code Style
+
+### Formatting
+- Use `terraform fmt` before committing
+- 2 spaces for indentation
+- Blank line between resource blocks
+
+### Ordering
+1. `terraform` block
+2. `provider` blocks
+3. `data` sources
+4. `locals`
+5. `resource` blocks
+6. `module` blocks
+
+### Comments
+```hcl
+# Comment for humans
+resource "aws_vpc" "main" {
+  # This CIDR block provides 65,536 IPs
+  cidr_block = "10.0.0.0/16"
+  
+  # Enable DNS for Route53 private zones
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+```
+
+## Common Patterns
+
+### Count vs For_Each
+
+#### Use count for simple replication
+```hcl
+resource "aws_subnet" "private" {
+  count             = 3
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+}
+```
+
+#### Use for_each for maps/sets
+```hcl
+resource "aws_subnet" "private" {
+  for_each = var.private_subnets
+  
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+  
+  tags = {
+    Name = each.key
+  }
+}
+```
+
+### Conditional Resources
+```hcl
+resource "aws_nat_gateway" "main" {
+  count = var.enable_nat_gateway ? 1 : 0
+  
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public[0].id
+}
+```
+
+### Locals for Computed Values
+```hcl
+locals {
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+  }
+  
+  az_count = min(length(data.aws_availability_zones.available.names), 3)
+}
+
+resource "aws_subnet" "private" {
+  count = local.az_count
+  # ...
+  tags = merge(local.common_tags, { Name = "private-${count.index}" })
+}
+```
+
+## Common Mistakes to Avoid
+
+### ❌ Don't
+- Hardcode values that should be variables
+- Store secrets in code
+- Use generic resource names
+- Skip validation on inputs
+- Forget to add descriptions
+- Mix environments in same state
+- Commit `.terraform/` directory
+- Use `terraform apply -auto-approve` in CI without review
+
+### ✅ Do
+- Use variables for all configurable values
+- Use secrets manager for sensitive data
+- Use descriptive, consistent naming
+- Validate all user inputs
+- Document everything
+- Separate state per environment
+- Use `.gitignore` properly
+- Require approval for production changes
+
+## .gitignore for Terraform
+
+```gitignore
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files
+*.tfvars
+*.tfvars.json
+
+# Ignore override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you wish to add
+# !example_override.tf
+
+# Include tfplan files
+*tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+```
+
+## Pre-commit Hooks
+
+Example `.pre-commit-config.yaml`:
+```yaml
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.83.5
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_docs
+      - id: terraform_tflint
+```
+
+## Quick Reference
+
+### Essential Commands
+```bash
+
+# init
+terraform init
+
+# Format
+terraform fmt -recursive
+
+# Validate
+terraform validate
+
+# Plan
+terraform plan -out=tfplan
+
+# Apply
+terraform apply tfplan
+
+# Destroy
+terraform destroy
+```
+
+### Best Practices Checklist
+- [ ] Used descriptive resource names
+- [ ] Added descriptions to all variables and outputs
+- [ ] Validated all inputs
+- [ ] Tagged all resources
+- [ ] Pinned provider versions
+- [ ] Used remote state
+- [ ] No hardcoded values
+- [ ] No secrets in code
+- [ ] Ran terraform fmt
+- [ ] Provided examples
+- [ ] Updated README
+
+---


### PR DESCRIPTION
# Add contributing guidelines and templates for Terraform modules

## Description
This PR adds comprehensive contributing guidelines and documentation standards for the terraform-starter-kit project. It includes guidelines for pull requests, contribution standards, Terraform module best practices, and a template for Terraform module READMEs.

## Changes
- Added `CONTRIBUTING.md` with project contribution guidelines and setup instructions
- Added `pull-request-guidelines.md` with PR submission, review, and merge procedures
- Added `terraform-standards.md` with Terraform code standards and best practices
- Added `terraform-module-readme-template.md` with a standardised README template for Terraform modules

## Why
This improves project maintainability and developer experience by:
- Establishing clear expectations for contributors
- Ensuring consistent code quality and standards across modules
- Providing a structured template for module documentation
- Streamlining the PR review process with defined guidelines

## Testing
N/A

## Screenshots (if applicable)
N/A - Documentation only

## Related Issues
closes #10 
