### PR TITLE
Add MIT licence to repository

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 CoderCo Community (MOT Team)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
Add an MIT licence to clearly define usage

## Context / Motivation
The repository did not previously include a licence, which made reuse and contribution terms unclear.  
MIT was chosen over Apache 2.0 to keep licensing simple and low-friction for community contributors, without additional legal overhead.

## Changes
- Added MIT `LICENSE` file


## Type of Change
- [ ] Terraform module
- [ ] Example update
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] CI / Tooling

## Related Issues
Closes #25 

## Testing
- [ ] terraform fmt
- [ ] terraform validate
- [ ] examples validated
- [ ] tflint
- [ ] terratest (if applicable)
- [ ] tested manually
- [x] not applicable (documentation-only change)

## Evidence / Notes
No functional changes. Licence added for clarity and governance.

## Checklist
- [x] PR title is clear and descriptive
- [x] Code follows module conventions
- [x] Inputs and outputs are documented
- [x] No secrets or sensitive data included
