### PR TITLE
clarify ECS module requirements and limitations

### DIFF
--- a/examples/aws/ecs/basic/README.md
+++ b/examples/aws/ecs/basic/README.md
@@ -23,7 +23,7 @@ terraform apply
 - AWS Provider >= 6.24.0
 - Terraform >= 1.12.2
 - Valid AWS credentials configured
-- Existing VPC with subnets and security groups
+- Existing VPC with subnets and security groups **(must be created separately)**
 
 ## Inputs
 

--- a/modules/aws/ecs/README.md
+++ b/modules/aws/ecs/README.md
@@ -58,7 +58,8 @@ See [examples/](examples/) directory for complete examples.
 
 ## Notes
 
-- **Security groups are required** - You must provide at least one security group ID for the ECS service to function
+- **Fargate launch type only** - This module currently only supports the FARGATE launch type. EC2 launch type is not supported as of now.
+- **Security groups are required** - You must create and provide at least one security group ID for the ECS service. The module does not create security groups. Ensure your security groups allow the necessary inbound/outbound traffic for your service.
 - **Load balancer not included** – If you wish to use the load balancer feature, you must create the load balancer and target group yourself, and provide the target group to the module input.
 - All resources are automatically tagged with `ManagedBy` and `Module` tags via provider default_tags
 - The module creates IAM roles for task execution and task role. (task role will not be created if `use_custom_task_role` is set to `true` and `task_role_arn` is provided)

--- a/modules/aws/ecs/autoscaling.tf
+++ b/modules/aws/ecs/autoscaling.tf
@@ -1,0 +1,2 @@
+# TODO: Add ECS autoscaling configuration
+# This file is reserved for future implementation of ECS service autoscaling


### PR DESCRIPTION
## Summary
Addresses feedback from Main Branch PR code review to clarify ECS module requirements and limitations in documentation.

## Context / Motivation
Based on review feedback, the ECS module documentation needed clarification on:
- Fargate-only support (EC2 launch type not supported)
- Security group creation requirements
- Empty autoscaling.tf file

## Type of Change
- [x] Documentation

## Related Issues
Addresses review comments #27 

## Testing
- [x] not applicable (documentation only)

## Evidence / Notes
Changes include:
- Added Fargate-only note to ECS module README
- Enhanced security group requirement clarity in module README and example
- Added TODO comment to empty autoscaling.tf file